### PR TITLE
Add Docker attack notes and scripts

### DIFF
--- a/containers/Docker/attacks/capabilities_matrix.md
+++ b/containers/Docker/attacks/capabilities_matrix.md
@@ -1,0 +1,7 @@
+# Linux Capabilities Matrix
+
+| Capability | Description |
+|------------|-------------|
+| SYS_ADMIN  | Broad system control; enables many escape techniques. |
+| NET_ADMIN  | Modify networking; potential for packet capture or spoofing. |
+| SYS_PTRACE | Allows tracing other processes. |

--- a/containers/Docker/attacks/dangerous_flags.md
+++ b/containers/Docker/attacks/dangerous_flags.md
@@ -1,0 +1,5 @@
+# Dangerous Docker Run Flags
+
+- `--privileged` grants all capabilities and disables many security mechanisms.
+- `--cap-add=SYS_ADMIN` exposes host devices and allows numerous escapes.
+- `-v /:/host` mounts the host root filesystem, often leading to full compromise.

--- a/containers/Docker/attacks/docker-audit-wrapper.sh
+++ b/containers/Docker/attacks/docker-audit-wrapper.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Wrapper around docker to log commands. Useful for auditing container actions.
+
+echo "[audit] docker $@" >> docker-audit.log
+exec docker "$@"

--- a/containers/Docker/attacks/docker_attack_notes.md
+++ b/containers/Docker/attacks/docker_attack_notes.md
@@ -1,0 +1,19 @@
+# Docker Container Threat Landscape
+
+These notes capture how attackers typically target Docker environments and what to explore next.
+
+## Threat Landscape
+- Exposed Docker daemons allow remote code execution.
+- Misconfigured container privileges lead to host compromise.
+- Vulnerable images introduce outdated packages and secrets.
+
+## Attack Vectors
+1. **Docker socket abuse** – Mounting `/var/run/docker.sock` grants root-equivalent control.
+2. **Namespace escapes** – Bugs or capabilities letting a process leave PID or mount namespaces.
+3. **Capability abuse** – Adding powerful capabilities like `SYS_ADMIN` or `NET_ADMIN`.
+4. **Dangerous flags** – Running containers with `--privileged` or extensive `--cap-add`.
+
+## Next Steps
+- Develop proof-of-concept scripts for privilege escalation via the Docker socket.
+- Test PID namespace escapes and monitor with ps namespace checks.
+- Create auditing wrappers around `docker` to log risky operations.

--- a/containers/Docker/attacks/docker_escape_cheatsheet.md
+++ b/containers/Docker/attacks/docker_escape_cheatsheet.md
@@ -1,0 +1,6 @@
+# Docker Escape Cheatsheet
+
+- Abuse the Docker socket if mounted.
+- Exploit kernel vulnerabilities from privileged containers.
+- Leverage capabilities like `SYS_PTRACE` or `SYS_MODULE` when available.
+- Check for sensitive mounts such as the host root or `/proc`.

--- a/containers/Docker/attacks/docker_sock_takeover.py
+++ b/containers/Docker/attacks/docker_sock_takeover.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+"""Placeholder script illustrating control of Docker via its socket."""
+
+import os
+
+DOCKER_SOCK = os.environ.get("DOCKER_SOCK", "/var/run/docker.sock")
+print(f"Would attempt takeover using {DOCKER_SOCK}")

--- a/containers/Docker/attacks/netcap_monitor.sh
+++ b/containers/Docker/attacks/netcap_monitor.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Placeholder script to monitor containers with NET_ADMIN capability.
+
+echo "Scanning for containers with NET_ADMIN..."

--- a/containers/Docker/attacks/pid_namespace_escape.sh
+++ b/containers/Docker/attacks/pid_namespace_escape.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Placeholder for demonstrating a PID namespace escape.
+
+echo "Attempting PID namespace escape (placeholder)"

--- a/containers/Docker/attacks/privilege_escalation_demo.sh
+++ b/containers/Docker/attacks/privilege_escalation_demo.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Placeholder demo for escalating privileges from within a container.
+# This would showcase abuse of the Docker socket or mounted volumes.
+
+echo "Privilege escalation demo placeholder"

--- a/containers/Docker/attacks/ps_namespace_checker.py
+++ b/containers/Docker/attacks/ps_namespace_checker.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python3
+"""Check which PID namespace this process is running in."""
+
+from pathlib import Path
+
+ns = Path('/proc/self/ns/pid').readlink()
+print(f"Current PID namespace: {ns}")

--- a/containers/README.md
+++ b/containers/README.md
@@ -5,5 +5,6 @@ Study materials for container security with Docker and Kubernetes.
 ## Subtopics
 - Docker
 - Kubernetes
+- Attacks
 
-Code lives in `scripts/` while `notes/` stores design references.
+Code lives in `scripts/` while `notes/` stores design references. Sample breakout demos live in `attacks/`.

--- a/learning-log.md
+++ b/learning-log.md
@@ -115,3 +115,8 @@ LIMIT 50;
 
 ### Image Scanning Audit
 - Wrote a Python script to report critical scan findings. See [AWS/ECR/scripts/scan_audit.py](AWS/ECR/scripts/scan_audit.py) and [AWS/ECR/notes/scan-audit.md](AWS/ECR/notes/scan-audit.md).
+
+## 2025-06-08 – Attacking Docker Containers
+- Documented the container threat landscape and attack vectors in `containers/Docker/attacks/docker_attack_notes.md`.
+- Created placeholder demos for privilege escalation, namespace escapes, and auditing Docker usage.
+- Added reference material on capabilities, dangerous flags, and escape techniques.


### PR DESCRIPTION
## Summary
- outline Docker container threat landscape and attack vectors
- add placeholder exploits and helper scripts under `containers/Docker/attacks/`
- document dangerous container flags and Linux capability matrix
- update learning log with new Docker attack notes
- mention new attacks directory in container README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6845ee3cdfa08330b110a6a7dd4a93f2