### PR TITLE
Add container image hygiene notes and scripts

### DIFF
--- a/containers/Docker/examples/app.Dockerfile
+++ b/containers/Docker/examples/app.Dockerfile
@@ -1,0 +1,9 @@
+# Multi-stage build for a Go application using a distroless base
+FROM golang:1.21 AS builder
+WORKDIR /src
+COPY . .
+RUN CGO_ENABLED=0 go build -o /app
+
+FROM gcr.io/distroless/static
+COPY --from=builder /app /app
+ENTRYPOINT ["/app"]

--- a/containers/notes/image_hygiene.md
+++ b/containers/notes/image_hygiene.md
@@ -1,0 +1,43 @@
+# Container Image Hygiene
+
+These notes outline minimal image practices, scanning workflows, and runtime observability techniques.
+
+## Image Minimization
+
+- Prefer distroless or other minimal base images to reduce attack surface.
+- Use multi-stage builds so that compilers and tooling never ship in the final image.
+- Tools like `docker-slim` can remove unused binaries and generate seccomp profiles.
+
+Example multi-stage Dockerfile:
+
+```Dockerfile
+FROM golang:1.21 AS builder
+WORKDIR /src
+COPY . .
+RUN CGO_ENABLED=0 go build -o /app
+
+FROM gcr.io/distroless/static
+COPY --from=builder /app /app
+ENTRYPOINT ["/app"]
+```
+
+## Secrets Management
+
+- Never bake credentials into Dockerfiles.
+- Inject secrets at runtime via environment variables or mounted files.
+
+## Vulnerability Scanning
+
+Run scanners during CI to catch issues before deployment.
+Example using Trivy:
+
+```bash
+trivy image --severity HIGH,CRITICAL --exit-code 1 my-image:latest
+```
+
+Other tools include Grype and Clair.
+
+## Runtime Observability
+
+`osquery` can inspect running containers via SQL-like queries. Useful checks include detecting privileged containers, host path mounts, and exposed secrets.
+See the SQL files in `../osquery/` for sample policies.

--- a/containers/osquery/host_mounts.sql
+++ b/containers/osquery/host_mounts.sql
@@ -1,0 +1,2 @@
+-- List containers that have host paths mounted
+SELECT * FROM mounts WHERE path LIKE '/host%';

--- a/containers/osquery/privileged_containers.sql
+++ b/containers/osquery/privileged_containers.sql
@@ -1,0 +1,2 @@
+-- Detect containers running with the --privileged flag
+SELECT * FROM processes WHERE name='docker' AND cmdline LIKE '%--privileged%';

--- a/containers/osquery/sensitive_env_vars.sql
+++ b/containers/osquery/sensitive_env_vars.sql
@@ -1,0 +1,2 @@
+-- Identify environment variables that might contain secrets
+SELECT name, value FROM environment WHERE name LIKE '%KEY%' OR name LIKE '%TOKEN%';

--- a/containers/scripts/docker_slim_profile.sh
+++ b/containers/scripts/docker_slim_profile.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Run docker-slim to slim an image and print before/after sizes
+# Usage: ./docker_slim_profile.sh <image>
+set -euo pipefail
+IMAGE="$1"
+echo "Original image size:"
+docker images "$IMAGE" --format '{{.Repository}}:{{.Tag}} {{.Size}}'
+slim build --tag "$IMAGE.slim" "$IMAGE"
+echo "Slimmed image size:"
+docker images "$IMAGE.slim" --format '{{.Repository}}:{{.Tag}} {{.Size}}'

--- a/containers/scripts/trivy_scan.sh
+++ b/containers/scripts/trivy_scan.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Wrapper script to scan an image with Trivy
+# Usage: ./trivy_scan.sh <image>
+set -euo pipefail
+IMAGE="$1"
+trivy image --severity HIGH,CRITICAL --exit-code 1 "$IMAGE"

--- a/learning-log.md
+++ b/learning-log.md
@@ -120,3 +120,9 @@ LIMIT 50;
 - Documented the container threat landscape and attack vectors in `containers/Docker/attacks/docker_attack_notes.md`.
 - Created placeholder demos for privilege escalation, namespace escapes, and auditing Docker usage.
 - Added reference material on capabilities, dangerous flags, and escape techniques.
+
+## 2025-06-09 – Container Security: Image Hygiene, Vulnerability Scanning, and Runtime Observability
+- Added example multi-stage Dockerfile using a distroless base under `containers/Docker/examples/`.
+- Wrote `trivy_scan.sh` and `docker_slim_profile.sh` helper scripts in `containers/scripts/`.
+- Created `containers/osquery/` with SQL policies to detect privileged containers, host mounts, and sensitive environment variables.
+- Documented image hygiene and scanning tips in [containers/notes/image_hygiene.md](containers/notes/image_hygiene.md).


### PR DESCRIPTION
## Summary
- add example multi-stage distroless Dockerfile
- document container image hygiene and scanning tips
- add Trivy and docker-slim helper scripts
- provide osquery SQL policies for container audits
- log today's work in learning log

## Testing
- `bash -n containers/scripts/trivy_scan.sh`
- `bash -n containers/scripts/docker_slim_profile.sh`


------
https://chatgpt.com/codex/tasks/task_e_684870671f48833080856776b4500d59