### PR TITLE
Consolidate osquery queries, reorder log

### DIFF
--- a/containers/notes/image_hygiene.md
+++ b/containers/notes/image_hygiene.md
@@ -40,4 +40,4 @@ Other tools include Grype and Clair.
 ## Runtime Observability
 
 `osquery` can inspect running containers via SQL-like queries. Useful checks include detecting privileged containers, host path mounts, and exposed secrets.
-See the SQL files in `../osquery/` for sample policies.
+See `osquery/container_hunting_queries.sql` for sample policies.

--- a/containers/osquery/container_hunting_queries.sql
+++ b/containers/osquery/container_hunting_queries.sql
@@ -1,0 +1,12 @@
+-- Container Security Hunting Queries for osquery
+--
+-- This file consolidates common checks for discovering risky container activity.
+
+-- 1. Detect containers running with the --privileged flag
+SELECT * FROM processes WHERE name='docker' AND cmdline LIKE '%--privileged%';
+
+-- 2. List containers that have host paths mounted
+SELECT * FROM mounts WHERE path LIKE '/host%';
+
+-- 3. Identify environment variables that might contain secrets
+SELECT name, value FROM environment WHERE name LIKE '%KEY%' OR name LIKE '%TOKEN%';

--- a/containers/osquery/host_mounts.sql
+++ b/containers/osquery/host_mounts.sql
@@ -1,2 +1,0 @@
--- List containers that have host paths mounted
-SELECT * FROM mounts WHERE path LIKE '/host%';

--- a/containers/osquery/privileged_containers.sql
+++ b/containers/osquery/privileged_containers.sql
@@ -1,2 +1,0 @@
--- Detect containers running with the --privileged flag
-SELECT * FROM processes WHERE name='docker' AND cmdline LIKE '%--privileged%';

--- a/containers/osquery/sensitive_env_vars.sql
+++ b/containers/osquery/sensitive_env_vars.sql
@@ -1,2 +1,0 @@
--- Identify environment variables that might contain secrets
-SELECT name, value FROM environment WHERE name LIKE '%KEY%' OR name LIKE '%TOKEN%';

--- a/learning-log.md
+++ b/learning-log.md
@@ -1,6 +1,40 @@
 # Learning Log
 
-This log captures daily updates for cloud security experiments. Notes on detection and attack techniques are organized within each service directory.
+This log captures daily updates for cloud security experiments. Notes on detection and attack techniques are organized within each service directory. Newest updates appear first.
+
+## 2025-06-09 – Container Security: Image Hygiene, Vulnerability Scanning, and Runtime Observability
+- Added example multi-stage Dockerfile using a distroless base under `containers/Docker/examples/`.
+- Wrote `trivy_scan.sh` and `docker_slim_profile.sh` helper scripts in `containers/scripts/`.
+- Created `containers/osquery/container_hunting_queries.sql` with queries to detect privileged containers, host mounts, and sensitive environment variables.
+- Documented image hygiene and scanning tips in [containers/notes/image_hygiene.md](containers/notes/image_hygiene.md).
+## 2025-06-08 – Attacking Docker Containers
+- Documented the container threat landscape and attack vectors in `containers/Docker/attacks/docker_attack_notes.md`.
+- Created placeholder demos for privilege escalation, namespace escapes, and auditing Docker usage.
+- Added reference material on capabilities, dangerous flags, and escape techniques.
+## 2025-06-08 – Day 2: Logging and Monitoring
+
+### Tag Immutability
+- Enabled immutable tags through Terraform and verified enforcement with the AWS CLI.
+
+### CloudTrail Logging
+- Configured a trail to capture ECR actions for auditing. Steps documented in [AWS/ECR/notes/ecr-monitoring.md](AWS/ECR/notes/ecr-monitoring.md).
+
+### Athena Queries
+- Created a table over the CloudTrail bucket and executed:
+
+```sql
+SELECT eventTime, eventName, userIdentity.userName
+FROM ecr_cloudtrail_logs
+WHERE eventSource = 'ecr.amazonaws.com'
+ORDER BY eventTime DESC
+LIMIT 50;
+```
+
+### EventBridge Integration
+- Added rules to notify on image pushes. Details in [AWS/ECR/notes/eventbridge.md](AWS/ECR/notes/eventbridge.md).
+
+### Image Scanning Audit
+- Wrote a Python script to report critical scan findings. See [AWS/ECR/scripts/scan_audit.py](AWS/ECR/scripts/scan_audit.py) and [AWS/ECR/notes/scan-audit.md](AWS/ECR/notes/scan-audit.md).
 
 ## 2025-06-07 – Day 1: Amazon ECR
 
@@ -90,39 +124,3 @@ aws ecr put-image-tag-mutability \
   --image-tag-mutability IMMUTABLE
 ```
 
-
-## 2025-06-08 – Day 2: Logging and Monitoring
-
-### Tag Immutability
-- Enabled immutable tags through Terraform and verified enforcement with the AWS CLI.
-
-### CloudTrail Logging
-- Configured a trail to capture ECR actions for auditing. Steps documented in [AWS/ECR/notes/ecr-monitoring.md](AWS/ECR/notes/ecr-monitoring.md).
-
-### Athena Queries
-- Created a table over the CloudTrail bucket and executed:
-
-```sql
-SELECT eventTime, eventName, userIdentity.userName
-FROM ecr_cloudtrail_logs
-WHERE eventSource = 'ecr.amazonaws.com'
-ORDER BY eventTime DESC
-LIMIT 50;
-```
-
-### EventBridge Integration
-- Added rules to notify on image pushes. Details in [AWS/ECR/notes/eventbridge.md](AWS/ECR/notes/eventbridge.md).
-
-### Image Scanning Audit
-- Wrote a Python script to report critical scan findings. See [AWS/ECR/scripts/scan_audit.py](AWS/ECR/scripts/scan_audit.py) and [AWS/ECR/notes/scan-audit.md](AWS/ECR/notes/scan-audit.md).
-
-## 2025-06-08 – Attacking Docker Containers
-- Documented the container threat landscape and attack vectors in `containers/Docker/attacks/docker_attack_notes.md`.
-- Created placeholder demos for privilege escalation, namespace escapes, and auditing Docker usage.
-- Added reference material on capabilities, dangerous flags, and escape techniques.
-
-## 2025-06-09 – Container Security: Image Hygiene, Vulnerability Scanning, and Runtime Observability
-- Added example multi-stage Dockerfile using a distroless base under `containers/Docker/examples/`.
-- Wrote `trivy_scan.sh` and `docker_slim_profile.sh` helper scripts in `containers/scripts/`.
-- Created `containers/osquery/` with SQL policies to detect privileged containers, host mounts, and sensitive environment variables.
-- Documented image hygiene and scanning tips in [containers/notes/image_hygiene.md](containers/notes/image_hygiene.md).


### PR DESCRIPTION
## Summary
- merge individual osquery SQL files into one `container_hunting_queries.sql`
- reference the new query file in the image hygiene notes
- reorder `learning-log.md` so new entries go at the top and update the osquery file path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68487210bc408330846b4ca1ab73ceae