### PR TITLE
Add Tools directory and README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,16 @@ This repo includes real-world scenarios where I:
 - Deploy Terraform-managed infrastructure (with security focus)
 - Use Boto3 scripts for ECR scanning and secret rotation
 
+
+## Tools/
+
+- [Trivy](./Tools/trivy/)
+- [Clair](./Tools/clair/)
+- [Checkov](./Tools/checkov/)
+- [Osquery](./Tools/osquery/)
+- [Falco](./Tools/falco/)
+- [Grype](./Tools/grype/)
+
 ---
 
 ## 🚧 Work in Progress

--- a/Tools/README.md
+++ b/Tools/README.md
@@ -1,0 +1,2 @@
+This folder contains notes, configurations, and detection logic for commonly used security tools across cloud, container, and host environments.
+

--- a/Tools/checkov/README.md
+++ b/Tools/checkov/README.md
@@ -1,0 +1,1 @@
+Checkov is a static code analysis tool that detects misconfigurations in infrastructure-as-code frameworks like Terraform and CloudFormation.

--- a/Tools/clair/README.md
+++ b/Tools/clair/README.md
@@ -1,0 +1,1 @@
+Clair provides static vulnerability scanning for container images by analyzing layers and matching known CVEs.

--- a/Tools/falco/README.md
+++ b/Tools/falco/README.md
@@ -1,0 +1,1 @@
+Falco monitors system calls to detect anomalous behavior in containers and hosts at runtime.

--- a/Tools/grype/README.md
+++ b/Tools/grype/README.md
@@ -1,0 +1,1 @@
+Grype is a vulnerability scanner for container images and filesystems, providing detailed reports of known issues.

--- a/Tools/osquery/README.md
+++ b/Tools/osquery/README.md
@@ -1,0 +1,1 @@
+Osquery exposes the operating system as a relational database, enabling SQL-based investigation and detection on hosts and containers.

--- a/Tools/trivy/README.md
+++ b/Tools/trivy/README.md
@@ -1,0 +1,1 @@
+Trivy is a comprehensive vulnerability scanner for container images, file systems, and infrastructure-as-code templates.


### PR DESCRIPTION
## Summary
- add `Tools/` directory with brief README
- create subfolders for Trivy, Clair, Checkov, Osquery, Falco and Grype
- add basic descriptions for each tool
- link all tool folders in main README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684abac5fde08330a915dc2d3ad51035