### PR TITLE
Add secure Kubernetes YAML examples

### DIFF
--- a/Containers/Kubernetes/config/configmap-app-settings.yaml
+++ b/Containers/Kubernetes/config/configmap-app-settings.yaml
@@ -1,0 +1,11 @@
+# Application configuration
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: app-settings
+  namespace: default
+  labels:
+    app: backend
+data:
+  LOG_LEVEL: "info"
+  FEATURE_X_ENABLED: "true"

--- a/Containers/Kubernetes/config/daemonset-logging.yaml
+++ b/Containers/Kubernetes/config/daemonset-logging.yaml
@@ -1,0 +1,35 @@
+# DaemonSet for log shipping on each node
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: fluent-bit
+  labels:
+    app: logging
+spec:
+  selector:
+    matchLabels:
+      app: logging
+  template:
+    metadata:
+      labels:
+        app: logging
+    spec:
+      serviceAccountName: fluent-bit
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      containers:
+      - name: fluent-bit
+        image: fluent/fluent-bit:2.1
+        resources:
+          limits:
+            cpu: "100m"
+            memory: "128Mi"
+        volumeMounts:
+        - name: varlog
+          mountPath: /var/log
+          readOnly: true
+      volumes:
+      - name: varlog
+        hostPath:
+          path: /var/log

--- a/Containers/Kubernetes/config/deployment-secure.yaml
+++ b/Containers/Kubernetes/config/deployment-secure.yaml
@@ -1,0 +1,52 @@
+# Deployment with secure defaults
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: secure-app-deployment
+  namespace: default
+  labels:
+    app: secure-app
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: secure-app
+  template:
+    metadata:
+      labels:
+        app: secure-app
+    spec:
+      securityContext:
+        fsGroup: 2000              # group ID for shared volumes
+      containers:
+      - name: secure-app
+        image: nginx:1.25-alpine
+        ports:
+        - containerPort: 80
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "128Mi"
+          limits:
+            cpu: "250m"
+            memory: "256Mi"
+        # Container runs as non-root with a read-only filesystem
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 1000
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: ["ALL"]
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 80
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 80
+          initialDelaySeconds: 10
+          periodSeconds: 20

--- a/Containers/Kubernetes/config/ingress-basic.yaml
+++ b/Containers/Kubernetes/config/ingress-basic.yaml
@@ -1,0 +1,25 @@
+# Basic HTTPS Ingress with TLS
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: web-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+  labels:
+    app: web
+spec:
+  tls:
+  - hosts:
+    - example.com
+    secretName: web-tls
+  rules:
+  - host: example.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: frontend-svc
+            port:
+              number: 80

--- a/Containers/Kubernetes/config/initcontainer-wait-db.yaml
+++ b/Containers/Kubernetes/config/initcontainer-wait-db.yaml
@@ -1,0 +1,19 @@
+# Pod with init container waiting for database
+apiVersion: v1
+kind: Pod
+metadata:
+  name: init-wait-db
+spec:
+  initContainers:
+  - name: wait-db
+    image: busybox:1.36
+    command: ['sh', '-c', 'until nc -z db 5432; do sleep 2; done']
+  containers:
+  - name: app
+    image: nginx:1.25-alpine
+    ports:
+    - containerPort: 80
+    securityContext:
+      runAsNonRoot: true
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true

--- a/Containers/Kubernetes/config/limitrange-defaults.yaml
+++ b/Containers/Kubernetes/config/limitrange-defaults.yaml
@@ -1,0 +1,15 @@
+# Default resource requests/limits
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: default-limits
+  namespace: default
+spec:
+  limits:
+  - default:
+      cpu: "500m"
+      memory: 512Mi
+    defaultRequest:
+      cpu: "250m"
+      memory: 256Mi
+    type: Container

--- a/Containers/Kubernetes/config/networkpolicy-allow-app.yaml
+++ b/Containers/Kubernetes/config/networkpolicy-allow-app.yaml
@@ -1,0 +1,18 @@
+# Allow traffic to backend from frontend pods
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-frontend-to-backend
+  namespace: default
+spec:
+  podSelector:
+    matchLabels:
+      app: backend
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app: frontend
+    ports:
+    - protocol: TCP
+      port: 80

--- a/Containers/Kubernetes/config/networkpolicy-default-deny.yaml
+++ b/Containers/Kubernetes/config/networkpolicy-default-deny.yaml
@@ -1,0 +1,11 @@
+# Deny all ingress and egress in this namespace
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+  namespace: default
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress

--- a/Containers/Kubernetes/config/pod-minimal-secure.yaml
+++ b/Containers/Kubernetes/config/pod-minimal-secure.yaml
@@ -1,0 +1,25 @@
+# Simple pod running as non-root
+apiVersion: v1
+kind: Pod
+metadata:
+  name: minimal-secure-pod
+  labels:
+    app: demo
+spec:
+  securityContext:
+    runAsNonRoot: true
+    fsGroup: 3000
+  containers:
+  - name: demo
+    image: busybox:1.36
+    command: ["sleep", "3600"]
+    resources:
+      limits:
+        cpu: "50m"
+        memory: "64Mi"
+    securityContext:
+      runAsUser: 1000
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop: ["ALL"]

--- a/Containers/Kubernetes/config/podsecuritycontext.yaml
+++ b/Containers/Kubernetes/config/podsecuritycontext.yaml
@@ -1,0 +1,19 @@
+# PodSecurityContext example
+apiVersion: v1
+kind: Pod
+metadata:
+  name: secure-context-pod
+spec:
+  securityContext:
+    fsGroup: 2000
+    supplementalGroups: [3000]
+  containers:
+  - name: app
+    image: busybox:1.36
+    command: ["sleep", "3600"]
+    securityContext:
+      runAsUser: 1000
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      capabilities:
+        drop: ["ALL"]

--- a/Containers/Kubernetes/config/priorityclass-high.yaml
+++ b/Containers/Kubernetes/config/priorityclass-high.yaml
@@ -1,0 +1,9 @@
+# PriorityClass for critical workloads
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: high-priority
+value: 1000000
+preemptionPolicy: PreemptLowerPriority
+globalDefault: false
+description: "Used for critical system pods"

--- a/Containers/Kubernetes/config/replicaset-example.yaml
+++ b/Containers/Kubernetes/config/replicaset-example.yaml
@@ -1,0 +1,26 @@
+# ReplicaSet for a stateless app
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: demo-replicaset
+  labels:
+    app: demo
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: demo
+  template:
+    metadata:
+      labels:
+        app: demo
+    spec:
+      containers:
+      - name: demo
+        image: nginx:1.25-alpine
+        ports:
+        - containerPort: 80
+        resources:
+          limits:
+            cpu: "200m"
+            memory: "128Mi"

--- a/Containers/Kubernetes/config/resourcequota-example.yaml
+++ b/Containers/Kubernetes/config/resourcequota-example.yaml
@@ -1,0 +1,13 @@
+# Limit resources per namespace
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: compute-resources
+  namespace: default
+spec:
+  hard:
+    pods: "10"
+    requests.cpu: "1"
+    requests.memory: 1Gi
+    limits.cpu: "2"
+    limits.memory: 2Gi

--- a/Containers/Kubernetes/config/secret-env-injection.yaml
+++ b/Containers/Kubernetes/config/secret-env-injection.yaml
@@ -1,0 +1,19 @@
+# Pod using secret from environment variables
+apiVersion: v1
+kind: Pod
+metadata:
+  name: secret-env-pod
+spec:
+  containers:
+  - name: app
+    image: nginx:1.25-alpine
+    env:
+    - name: DB_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: db-secret
+          key: password
+    securityContext:
+      runAsNonRoot: true
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true

--- a/Containers/Kubernetes/config/service-clusterip.yaml
+++ b/Containers/Kubernetes/config/service-clusterip.yaml
@@ -1,0 +1,15 @@
+# Internal ClusterIP service
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend-svc
+  labels:
+    app: backend
+spec:
+  type: ClusterIP
+  selector:
+    app: backend
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8080

--- a/Containers/Kubernetes/config/service-loadbalancer.yaml
+++ b/Containers/Kubernetes/config/service-loadbalancer.yaml
@@ -1,0 +1,15 @@
+# Externally exposed service
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend-svc
+  labels:
+    app: frontend
+spec:
+  type: LoadBalancer
+  selector:
+    app: frontend
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8080

--- a/Containers/Kubernetes/config/statefulset-database.yaml
+++ b/Containers/Kubernetes/config/statefulset-database.yaml
@@ -1,0 +1,48 @@
+# StatefulSet for a database with persistent storage
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: db
+  labels:
+    app: database
+spec:
+  serviceName: db-headless
+  replicas: 3
+  selector:
+    matchLabels:
+      app: database
+  template:
+    metadata:
+      labels:
+        app: database
+    spec:
+      containers:
+      - name: postgres
+        image: postgres:15
+        env:
+        - name: POSTGRES_DB
+          value: "app"
+        ports:
+        - containerPort: 5432
+        volumeMounts:
+        - name: data
+          mountPath: /var/lib/postgresql/data
+        resources:
+          requests:
+            cpu: "250m"
+            memory: "256Mi"
+          limits:
+            cpu: "500m"
+            memory: "512Mi"
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 999
+          readOnlyRootFilesystem: false
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes: ["ReadWriteOnce"]
+      resources:
+        requests:
+          storage: 1Gi


### PR DESCRIPTION
## Summary
- create `Containers/Kubernetes/config` directory
- add secure Deployment, Pod, ReplicaSet, Service, StatefulSet, DaemonSet, NetworkPolicy, Ingress, quota and limit examples
- include ConfigMap, Secret injection, Pod security context, InitContainer usage and PriorityClass

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_684c2aa4cdac83308d2298eed25f2a95